### PR TITLE
Refactor router app error handling

### DIFF
--- a/backend/app/presentation/dependencies.py
+++ b/backend/app/presentation/dependencies.py
@@ -1,3 +1,5 @@
+import inspect
+from functools import wraps
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
@@ -173,12 +175,33 @@ def require_role(*allowed_roles: UserRole):
 
 def app_error_to_http(exc: AppError) -> HTTPException:
     mapping = {
-        NotFoundError:       status.HTTP_404_NOT_FOUND,
-        ConflictError:       status.HTTP_409_CONFLICT,
+        NotFoundError: status.HTTP_404_NOT_FOUND,
+        ConflictError: status.HTTP_409_CONFLICT,
         AuthenticationError: status.HTTP_401_UNAUTHORIZED,
-        AuthorizationError:  status.HTTP_403_FORBIDDEN,
-        BusinessRuleError:   status.HTTP_422_UNPROCESSABLE_ENTITY,
-        PaymentError:        status.HTTP_402_PAYMENT_REQUIRED,
+        AuthorizationError: status.HTTP_403_FORBIDDEN,
+        BusinessRuleError: status.HTTP_422_UNPROCESSABLE_CONTENT,
+        PaymentError: status.HTTP_402_PAYMENT_REQUIRED,
     }
     code = mapping.get(type(exc), status.HTTP_400_BAD_REQUEST)
     return HTTPException(status_code=code, detail=str(exc))
+
+
+def handle_app_errors(func):
+    if inspect.iscoroutinefunction(func):
+        @wraps(func)
+        async def _async_wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except AppError as exc:
+                raise app_error_to_http(exc) from exc
+
+        return _async_wrapper
+
+    @wraps(func)
+    def _sync_wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except AppError as exc:
+            raise app_error_to_http(exc) from exc
+
+    return _sync_wrapper

--- a/backend/app/presentation/routers/auth_router.py
+++ b/backend/app/presentation/routers/auth_router.py
@@ -1,9 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from backend.app.application.exceptions import AuthenticationError, ConflictError
 from backend.app.application.services.auth_service import AuthService
 from backend.app.domain.models.user import UserRole
-from backend.app.presentation.dependencies import get_auth_service
+from backend.app.presentation.dependencies import get_auth_service, handle_app_errors
 from backend.app.presentation.schemas import (
     LoginRequest,
     RegisterRequest,
@@ -20,6 +19,7 @@ router = APIRouter(prefix="/auth", tags=["Authentication"])
     status_code=status.HTTP_201_CREATED,
     summary="Register a new user account",
 )
+@handle_app_errors
 def register(
     body: RegisterRequest,
     auth_svc: AuthService = Depends(get_auth_service),
@@ -31,21 +31,18 @@ def register(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid role '{body.role}'. Must be one of: {[r.value for r in UserRole]}",
         )
-    try:
-        user = auth_svc.register(
-            email=body.email,
-            password=body.password,
-            role=role,
-            name=body.name,
-            age=body.age,
-            gender=body.gender,
-            location=body.location,
-            preferred_cuisine=body.preferred_cuisine,
-            order_frequency=body.order_frequency,
-            loyalty_program=body.loyalty_program,
-        )
-    except ConflictError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+    user = auth_svc.register(
+        email=body.email,
+        password=body.password,
+        role=role,
+        name=body.name,
+        age=body.age,
+        gender=body.gender,
+        location=body.location,
+        preferred_cuisine=body.preferred_cuisine,
+        order_frequency=body.order_frequency,
+        loyalty_program=body.loyalty_program,
+    )
 
     return UserResponse(
         customer_id=user.customer_id,
@@ -65,13 +62,11 @@ def register(
     response_model=TokenResponse,
     summary="Log in and receive a JWT access token",
 )
+@handle_app_errors
 def login(
     body: LoginRequest,
     auth_svc: AuthService = Depends(get_auth_service),
 ):
-    try:
-        token = auth_svc.login(body.email, body.password)
-    except AuthenticationError as exc:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc))
+    token = auth_svc.login(body.email, body.password)
 
     return TokenResponse(access_token=token)

--- a/backend/app/presentation/routers/delivery_router.py
+++ b/backend/app/presentation/routers/delivery_router.py
@@ -1,15 +1,14 @@
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query, status
 
-from backend.app.application.exceptions import (
-    AuthorizationError,
-    BusinessRuleError,
-    NotFoundError,
-)
 from backend.app.application.services.delivery_service import DeliveryService
 from backend.app.domain.models.user import User
-from backend.app.presentation.dependencies import get_current_user, get_delivery_service
+from backend.app.presentation.dependencies import (
+    get_current_user,
+    get_delivery_service,
+    handle_app_errors,
+)
 from backend.app.presentation.schemas import (
     AssignDeliveryRequest,
     UpdateDeliveryRequest,
@@ -36,37 +35,29 @@ def _to_response(delivery) -> DeliveryResponse:
     )
 
 @router.post("/{order_id}", response_model=DeliveryResponse, status_code=status.HTTP_201_CREATED)
+@handle_app_errors
 def assign_delivery(
     order_id: str,
     body: AssignDeliveryRequest,
     current_user: User = Depends(get_current_user),
     svc: DeliveryService = Depends(get_delivery_service),
 ):
-    try:
-        delivery = svc.assign_delivery(
-            requesting_user=current_user,
-            order_id=order_id,
-            delivery_method=body.delivery_method,
-            delivery_distance=body.delivery_distance,
-            estimated_delivery_time=body.estimated_delivery_time,
-        )
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except BusinessRuleError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
+    delivery = svc.assign_delivery(
+        requesting_user=current_user,
+        order_id=order_id,
+        delivery_method=body.delivery_method,
+        delivery_distance=body.delivery_distance,
+        estimated_delivery_time=body.estimated_delivery_time,
+    )
     return _to_response(delivery)
 
 @router.get("/{order_id}", response_model=DeliveryResponse)
+@handle_app_errors
 def get_delivery(
     order_id: str,
     svc: DeliveryService = Depends(get_delivery_service),
 ):
-    try:
-        delivery = svc.get_delivery(order_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    delivery = svc.get_delivery(order_id)
     return _to_response(delivery)
 
 @router.get("", response_model=List[DeliveryResponse])
@@ -78,29 +69,25 @@ def list_deliveries(
     return [_to_response(d) for d in svc.list_deliveries(offset=offset, limit=limit)]
 
 @router.patch("/{order_id}", response_model=DeliveryResponse)
+@handle_app_errors
 def update_delivery(
     order_id: str,
     body: UpdateDeliveryRequest,
     current_user: User = Depends(get_current_user),
     svc: DeliveryService = Depends(get_delivery_service),
 ):
-    try:
-        updated = svc.update_delivery(
-            requesting_user=current_user,
-            order_id=order_id,
-            delivery_time_actual=body.delivery_time_actual,
-            delivery_delay=body.delivery_delay,
-            delivery_method=body.delivery_method,
-            route_taken=body.route_taken,
-            route_type=body.route_type,
-            route_efficiency=body.route_efficiency,
-            traffic_condition=body.traffic_condition,
-            weather_condition=body.weather_condition,
-            predicted_delivery_mode=body.predicted_delivery_mode,
-            traffic_avoidance=body.traffic_avoidance,
-        )
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    updated = svc.update_delivery(
+        requesting_user=current_user,
+        order_id=order_id,
+        delivery_time_actual=body.delivery_time_actual,
+        delivery_delay=body.delivery_delay,
+        delivery_method=body.delivery_method,
+        route_taken=body.route_taken,
+        route_type=body.route_type,
+        route_efficiency=body.route_efficiency,
+        traffic_condition=body.traffic_condition,
+        weather_condition=body.weather_condition,
+        predicted_delivery_mode=body.predicted_delivery_mode,
+        traffic_avoidance=body.traffic_avoidance,
+    )
     return _to_response(updated)

--- a/backend/app/presentation/routers/menu_router.py
+++ b/backend/app/presentation/routers/menu_router.py
@@ -2,11 +2,14 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from backend.app.application.exceptions import AuthorizationError, NotFoundError
 from backend.app.application.services.menu_service import MenuService
 from backend.app.domain.models.menu_item import MenuItem
 from backend.app.domain.models.user import User
-from backend.app.presentation.dependencies import get_current_user, get_menu_service
+from backend.app.presentation.dependencies import (
+    get_current_user,
+    get_menu_service,
+    handle_app_errors,
+)
 from backend.app.presentation.schemas import (
     CreateMenuItemRequest,
     MenuItemResponse,
@@ -32,6 +35,7 @@ def _to_response(item: MenuItem) -> MenuItemResponse:
     status_code=status.HTTP_201_CREATED,
     summary="Add an item to a restaurant's menu (owner only)",
 )
+@handle_app_errors
 def add_menu_item(
     restaurant_id: str,
     body: CreateMenuItemRequest,
@@ -46,10 +50,6 @@ def add_menu_item(
             category=body.category,
             price=body.price,
         )
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     return _to_response(item)
@@ -60,6 +60,7 @@ def add_menu_item(
     response_model=List[MenuItemResponse],
     summary="Get all menu items for a restaurant",
 )
+@handle_app_errors
 def get_restaurant_menu(
     restaurant_id: str,
     offset: int = Query(default=0, ge=0),
@@ -67,12 +68,9 @@ def get_restaurant_menu(
     current_user: User = Depends(get_current_user),
     menu_svc: MenuService = Depends(get_menu_service),
 ):
-    try:
-        items = menu_svc.list_items_paginated(
-            restaurant_id=restaurant_id, offset=offset, limit=limit
-        )
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    items = menu_svc.list_items_paginated(
+        restaurant_id=restaurant_id, offset=offset, limit=limit
+    )
     return [_to_response(i) for i in items]
 
 
@@ -118,15 +116,13 @@ def filter_menu_items(
     response_model=MenuItemResponse,
     summary="Get a single menu item by ID",
 )
+@handle_app_errors
 def get_menu_item(
     food_item_id: str,
     current_user: User = Depends(get_current_user),
     menu_svc: MenuService = Depends(get_menu_service),
 ):
-    try:
-        item = menu_svc.get_item(food_item_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    item = menu_svc.get_item(food_item_id)
     return _to_response(item)
 
 
@@ -135,6 +131,7 @@ def get_menu_item(
     response_model=MenuItemResponse,
     summary="Update a menu item (owner only)",
 )
+@handle_app_errors
 def update_menu_item(
     food_item_id: str,
     body: UpdateMenuItemRequest,
@@ -149,10 +146,6 @@ def update_menu_item(
             category=body.category,
             price=body.price,
         )
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     return _to_response(updated)
@@ -163,14 +156,10 @@ def update_menu_item(
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Delete a menu item (owner only)",
 )
+@handle_app_errors
 def delete_menu_item(
     food_item_id: str,
     current_user: User = Depends(get_current_user),
     menu_svc: MenuService = Depends(get_menu_service),
 ):
-    try:
-        menu_svc.delete_item(current_user, food_item_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    menu_svc.delete_item(current_user, food_item_id)

--- a/backend/app/presentation/routers/notification_router.py
+++ b/backend/app/presentation/routers/notification_router.py
@@ -1,13 +1,13 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 
-from backend.app.application.exceptions import AuthorizationError, NotFoundError
 from backend.app.application.services.notification_service import NotificationService
 from backend.app.domain.models.user import User
 from backend.app.presentation.dependencies import (
     get_current_user,
     get_notification_service,
+    handle_app_errors,
 )
 from backend.app.presentation.schemas import NotificationResponse
 
@@ -30,16 +30,14 @@ def _to_response(notification) -> NotificationResponse:
     response_model=List[NotificationResponse],
     summary="Get all notifications for the current user",
 )
+@handle_app_errors
 def get_my_notifications(
     current_user: User = Depends(get_current_user),
     notification_svc: NotificationService = Depends(get_notification_service),
 ):
-    try:
-        notifications = notification_svc.get_all_for_user(
-            current_user, current_user.customer_id
-        )
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    notifications = notification_svc.get_all_for_user(
+        current_user, current_user.customer_id
+    )
     return [_to_response(notification) for notification in notifications]
 
 
@@ -48,16 +46,14 @@ def get_my_notifications(
     response_model=List[NotificationResponse],
     summary="Get unread notifications for the current user",
 )
+@handle_app_errors
 def get_unread_notifications(
     current_user: User = Depends(get_current_user),
     notification_svc: NotificationService = Depends(get_notification_service),
 ):
-    try:
-        notifications = notification_svc.get_unread_for_user(
-            current_user, current_user.customer_id
-        )
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    notifications = notification_svc.get_unread_for_user(
+        current_user, current_user.customer_id
+    )
     return [_to_response(notification) for notification in notifications]
 
 
@@ -66,17 +62,13 @@ def get_unread_notifications(
     response_model=NotificationResponse,
     summary="Mark a single notification as read",
 )
+@handle_app_errors
 def mark_notification_read(
     notification_id: int,
     current_user: User = Depends(get_current_user),
     notification_svc: NotificationService = Depends(get_notification_service),
 ):
-    try:
-        updated = notification_svc.mark_read(current_user, notification_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    updated = notification_svc.mark_read(current_user, notification_id)
     return _to_response(updated)
 
 
@@ -84,14 +76,12 @@ def mark_notification_read(
     "/read-all",
     summary="Mark all notifications as read for the current user",
 )
+@handle_app_errors
 def mark_all_read(
     current_user: User = Depends(get_current_user),
     notification_svc: NotificationService = Depends(get_notification_service),
 ):
-    try:
-        count = notification_svc.mark_all_read(current_user, current_user.customer_id)
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    count = notification_svc.mark_all_read(current_user, current_user.customer_id)
     return {"marked_read": count}
 
 
@@ -100,14 +90,10 @@ def mark_all_read(
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Delete a notification",
 )
+@handle_app_errors
 def delete_notification(
     notification_id: int,
     current_user: User = Depends(get_current_user),
     notification_svc: NotificationService = Depends(get_notification_service),
 ):
-    try:
-        notification_svc.delete_notification(current_user, notification_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    notification_svc.delete_notification(current_user, notification_id)

--- a/backend/app/presentation/routers/order_router.py
+++ b/backend/app/presentation/routers/order_router.py
@@ -2,16 +2,15 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from backend.app.application.exceptions import (
-    AuthorizationError,
-    BusinessRuleError,
-    NotFoundError,
-)
 from backend.app.application.services.order_service import OrderService
 from backend.app.domain.models.enums import OrderStatus
 from backend.app.domain.models.orders import Order
 from backend.app.domain.models.user import User, UserRole
-from backend.app.presentation.dependencies import get_current_user, get_order_service
+from backend.app.presentation.dependencies import (
+    get_current_user,
+    get_order_service,
+    handle_app_errors,
+)
 from backend.app.presentation.schemas import OrderResponse, PlaceOrderRequest
 
 router = APIRouter(prefix="/orders", tags=["Orders"])
@@ -37,26 +36,17 @@ def _to_response(order: Order) -> OrderResponse:
     status_code=status.HTTP_201_CREATED,
     summary="Place a new order (customers only)",
 )
+@handle_app_errors
 def place_order(
     body: PlaceOrderRequest,
     current_user: User = Depends(get_current_user),
     order_svc: OrderService = Depends(get_order_service),
 ):
-    try:
-        order = order_svc.place_order(
-            requesting_user=current_user,
-            restaurant_id=body.restaurant_id,
-            food_item_ids=body.food_item_ids,
-        )
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except BusinessRuleError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=str(exc),
-        )
+    order = order_svc.place_order(
+        requesting_user=current_user,
+        restaurant_id=body.restaurant_id,
+        food_item_ids=body.food_item_ids,
+    )
     return _to_response(order)
 
 
@@ -100,15 +90,13 @@ def list_my_orders(
     response_model=List[OrderResponse],
     summary="Get all orders for a restaurant (owners only)",
 )
+@handle_app_errors
 def get_restaurant_orders(
     restaurant_id: str,
     current_user: User = Depends(get_current_user),
     order_svc: OrderService = Depends(get_order_service),
 ):
-    try:
-        orders = order_svc.get_orders_for_restaurant(current_user, restaurant_id)
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    orders = order_svc.get_orders_for_restaurant(current_user, restaurant_id)
     return [_to_response(o) for o in orders]
 
 
@@ -117,15 +105,13 @@ def get_restaurant_orders(
     response_model=OrderResponse,
     summary="Get a single order by ID",
 )
+@handle_app_errors
 def get_order(
     order_id: str,
     current_user: User = Depends(get_current_user),
     order_svc: OrderService = Depends(get_order_service),
 ):
-    try:
-        order = order_svc.get_order(order_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    order = order_svc.get_order(order_id)
 
     if (
         current_user.role == UserRole.CUSTOMER
@@ -144,20 +130,11 @@ def get_order(
     response_model=OrderResponse,
     summary="Cancel a pending order",
 )
+@handle_app_errors
 def cancel_order(
     order_id: str,
     current_user: User = Depends(get_current_user),
     order_svc: OrderService = Depends(get_order_service),
 ):
-    try:
-        order = order_svc.cancel_order(current_user, order_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
-    except BusinessRuleError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=str(exc),
-        )
+    order = order_svc.cancel_order(current_user, order_id)
     return _to_response(order)

--- a/backend/app/presentation/routers/payment_router.py
+++ b/backend/app/presentation/routers/payment_router.py
@@ -1,14 +1,12 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 
-from backend.app.application.exceptions import (
-    AuthorizationError,
-    BusinessRuleError,
-    NotFoundError,
-    PaymentError,
-)
 from backend.app.application.services.payment_service import PaymentService
 from backend.app.domain.models.user import User
-from backend.app.presentation.dependencies import get_current_user, get_payment_service
+from backend.app.presentation.dependencies import (
+    get_current_user,
+    get_payment_service,
+    handle_app_errors,
+)
 from backend.app.presentation.schemas import PaymentResponse
 
 router = APIRouter(prefix="/payments", tags=["Payments"])
@@ -24,21 +22,13 @@ router = APIRouter(prefix="/payments", tags=["Payments"])
         422: {"description": "Order is not in a payable state"},
     },
 )
+@handle_app_errors
 def process_payment(
     order_id: str,
     current_user: User = Depends(get_current_user),
     payment_svc: PaymentService = Depends(get_payment_service),
 ):
-    try:
-        result = payment_svc.process_payment(order_id, current_user)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
-    except BusinessRuleError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
-    except PaymentError as exc:
-        raise HTTPException(status_code=status.HTTP_402_PAYMENT_REQUIRED, detail=str(exc))
+    result = payment_svc.process_payment(order_id, current_user)
 
     return PaymentResponse(
         order_id=result.order_id,

--- a/backend/app/presentation/routers/restaurant_router.py
+++ b/backend/app/presentation/routers/restaurant_router.py
@@ -1,17 +1,22 @@
-from typing import List, Optional 
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from backend.app.application.exceptions import AuthorizationError, NotFoundError
 from backend.app.application.services.restaurant_service import RestaurantService
-from backend.app.domain.models.user import User 
-from backend.app.presentation.dependencies import get_current_user, get_restaurant_service
-from backend.app.presentation.schemas import(
-    CreateRestaurantRequest,
-    UpdateRestaurantRequest,
-    RestaurantResponse,
+from backend.app.domain.models.user import User
+from backend.app.presentation.dependencies import (
+    get_current_user,
+    get_restaurant_service,
+    handle_app_errors,
 )
-router = APIRouter(prefix ="/restaurants", tags=["Restaurants"])
+from backend.app.presentation.schemas import (
+    CreateRestaurantRequest,
+    RestaurantResponse,
+    UpdateRestaurantRequest,
+)
+
+router = APIRouter(prefix="/restaurants", tags=["Restaurants"])
+
 
 def _to_response(restaurant) -> RestaurantResponse:
     return RestaurantResponse(
@@ -20,39 +25,34 @@ def _to_response(restaurant) -> RestaurantResponse:
         name=restaurant.name,
         location=restaurant.location,
         description=restaurant.description,
-
     )
 
+
 @router.post("", response_model=RestaurantResponse, status_code=status.HTTP_201_CREATED)
+@handle_app_errors
 def create_restaurant(
     body: CreateRestaurantRequest,
     current_user: User = Depends(get_current_user),
-    svc: RestaurantService = Depends(get_restaurant_service)
-
+    svc: RestaurantService = Depends(get_restaurant_service),
 ):
-    try:
-        restaurant = svc.create_restaurant(
-            requesting_user = current_user, 
-            name = body.name,
-            location = body.location, 
-            description = body.description,
-        )
-
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail =str(exc))
+    restaurant = svc.create_restaurant(
+        requesting_user=current_user,
+        name=body.name,
+        location=body.location,
+        description=body.description,
+    )
     return _to_response(restaurant)
+
 
 @router.get("/{restaurant_id}", response_model=RestaurantResponse)
+@handle_app_errors
 def get_restaurant(
-    restaurant_id: str, 
-    svc: RestaurantService = Depends(get_restaurant_service)
-
+    restaurant_id: str,
+    svc: RestaurantService = Depends(get_restaurant_service),
 ):
-    try: 
-        restaurant = svc.get_restaurant(restaurant_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail = str(exc))
+    restaurant = svc.get_restaurant(restaurant_id)
     return _to_response(restaurant)
+
 
 @router.get("", response_model=List[RestaurantResponse])
 def list_restaurants(
@@ -68,6 +68,7 @@ def list_restaurants(
         restaurants = svc.list_restaurants(location=location, offset=offset, limit=limit)
     return [_to_response(r) for r in restaurants]
 
+
 @router.get("/owner/{owner_id}", response_model=List[RestaurantResponse])
 def get_owner_restaurants(
     owner_id: str,
@@ -75,36 +76,30 @@ def get_owner_restaurants(
 ):
     return [_to_response(r) for r in svc.get_owner_restaurants(owner_id)]
 
+
 @router.patch("/{restaurant_id}", response_model=RestaurantResponse)
+@handle_app_errors
 def update_restaurant(
     restaurant_id: str,
     body: UpdateRestaurantRequest,
     current_user: User = Depends(get_current_user),
     svc: RestaurantService = Depends(get_restaurant_service),
 ):
-    try:
-        updated = svc.update_restaurant(
-            requesting_user=current_user,
-            restaurant_id=restaurant_id,
-            name=body.name,
-            location=body.location,
-            description=body.description,
-        )
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    updated = svc.update_restaurant(
+        requesting_user=current_user,
+        restaurant_id=restaurant_id,
+        name=body.name,
+        location=body.location,
+        description=body.description,
+    )
     return _to_response(updated)
 
+
 @router.delete("/{restaurant_id}", status_code=status.HTTP_204_NO_CONTENT)
+@handle_app_errors
 def delete_restaurant(
     restaurant_id: str,
     current_user: User = Depends(get_current_user),
     svc: RestaurantService = Depends(get_restaurant_service),
 ):
-    try:
-        svc.delete_restaurant(requesting_user=current_user, restaurant_id=restaurant_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
-    except AuthorizationError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc))
+    svc.delete_restaurant(requesting_user=current_user, restaurant_id=restaurant_id)

--- a/backend/app/presentation/routers/user_router.py
+++ b/backend/app/presentation/routers/user_router.py
@@ -2,10 +2,13 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from backend.app.application.exceptions import AuthorizationError, NotFoundError
 from backend.app.application.services.user_service import UserService
 from backend.app.domain.models.user import User, UserRole
-from backend.app.presentation.dependencies import get_current_user, get_user_service
+from backend.app.presentation.dependencies import (
+    get_current_user,
+    get_user_service,
+    handle_app_errors,
+)
 from backend.app.presentation.schemas import (
     ChangeRoleRequest,
     UpdateProfileRequest,
@@ -87,6 +90,7 @@ def list_users(
     response_model=UserResponse,
     summary="Get a user by ID",
 )
+@handle_app_errors
 def get_user(
     customer_id: str,
     current_user: User = Depends(get_current_user),
@@ -100,10 +104,7 @@ def get_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You can only view your own profile.",
         )
-    try:
-        user = user_svc.get_user(customer_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    user = user_svc.get_user(customer_id)
     return _to_response(user)
 
 
@@ -112,6 +113,7 @@ def get_user(
     response_model=UserResponse,
     summary="Change a user's role (restaurant owners only)",
 )
+@handle_app_errors
 def change_role(
     customer_id: str,
     body: ChangeRoleRequest,
@@ -125,15 +127,7 @@ def change_role(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid role '{body.new_role}'.",
         )
-    try:
-        updated = user_svc.change_role(current_user, customer_id, new_role)
-    except (AuthorizationError, NotFoundError) as exc:
-        code = (
-            status.HTTP_403_FORBIDDEN
-            if isinstance(exc, AuthorizationError)
-            else status.HTTP_404_NOT_FOUND
-        )
-        raise HTTPException(status_code=code, detail=str(exc))
+    updated = user_svc.change_role(current_user, customer_id, new_role)
     return _to_response(updated)
 
 
@@ -142,6 +136,7 @@ def change_role(
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Delete a user account",
 )
+@handle_app_errors
 def delete_user(
     customer_id: str,
     current_user: User = Depends(get_current_user),
@@ -152,7 +147,4 @@ def delete_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You can only delete your own account.",
         )
-    try:
-        user_svc.delete_user(customer_id)
-    except NotFoundError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    user_svc.delete_user(customer_id)


### PR DESCRIPTION
This PR refactors the presentation layer to centralize application error handling across routers.


  - added a shared `handle_app_errors` decorator in `backend/app/presentation/dependencies.py`
  - centralized `AppError` to `HTTPException` mapping in one place
  - removed repeated router-level `try/except` blocks where they were only translating application exceptions
  - applied the shared error handling pattern across auth, order, notification, payment, delivery, menu, restaurant, and user routers
  - updated business-rule error mapping to use the non-deprecated 422 status constant


  Passed:
  - `pytest tests/api/test_payment_router.py tests/api/test_order_router.py`
  - `pytest tests/api/test_order_router.py tests/api/test_notification_router.py tests/api/test_delivery_router.py tests/api/test_menu_router.py
  tests/api/test_restaurant_router.py tests/api/test_auth_router.py tests/api/test_user_router.py`
  - `pytest tests/unit/test_order_services.py tests/unit/test_notification_service.py tests/unit/test_auth_service.py