### PR TITLE
Refactor notification domain flow

### DIFF
--- a/backend/app/application/services/notification_service.py
+++ b/backend/app/application/services/notification_service.py
@@ -1,11 +1,10 @@
 from typing import List
 
 from backend.app.application.exceptions import AuthorizationError, NotFoundError
+from backend.app.domain.models.notification import Notification
 from backend.app.domain.models.user import User
-from backend.app.infrastructure.repositories.notification_repository import (
-    Notification,
-    NotificationRepository,
-)
+from backend.app.domain.models.user import UserRole
+from backend.app.infrastructure.repositories.notification_repository import NotificationRepository
 
 class NotificationService:
 
@@ -29,20 +28,13 @@ class NotificationService:
         return self._notifications.get_unread_by_user(user_id)
 
     def get_notification(self, requesting_user: User, notification_id: int) -> Notification:
-        notification = self._notifications.get_by_id(notification_id)
-        if notification is None:
-            raise NotFoundError(f"Notification '{notification_id}' not found.")
-        self._assert_can_read(requesting_user, notification.user_id)
-        return notification
+        return self._get_notification_for_user(requesting_user, notification_id)
 
     def mark_read(self, requesting_user: User, notification_id: int) -> Notification:
-        notification = self._notifications.get_by_id(notification_id)
-        if notification is None:
-            raise NotFoundError(f"Notification '{notification_id}' not found.")
-
-        self._assert_can_read(requesting_user, notification.user_id)
-
+        self._get_notification_for_user(requesting_user, notification_id)
         updated = self._notifications.mark_as_read(notification_id)
+        if updated is None:
+            raise NotFoundError(f"Notification '{notification_id}' not found.")
         return updated
 
     def mark_all_read(self, requesting_user: User, user_id: str) -> int:
@@ -51,15 +43,10 @@ class NotificationService:
 
     def delete_notification(self, requesting_user: User, notification_id: int) -> None:
         """Delete a notification. Users can only delete their own."""
-        notification = self._notifications.get_by_id(notification_id)
-        if notification is None:
-            raise NotFoundError(f"Notification '{notification_id}' not found.")
-        self._assert_can_read(requesting_user, notification.user_id)
+        self._get_notification_for_user(requesting_user, notification_id)
         self._notifications.delete(notification_id)
 
     def _assert_can_read(self, requesting_user: User, target_user_id: str) -> None:
-
-        from backend.app.domain.models.user import UserRole
         if (
             requesting_user.role == UserRole.CUSTOMER
             and requesting_user.customer_id != target_user_id
@@ -67,3 +54,14 @@ class NotificationService:
             raise AuthorizationError(
                 "You can only access your own notifications."
             )
+
+    def _get_notification_for_user(
+        self,
+        requesting_user: User,
+        notification_id: int,
+    ) -> Notification:
+        notification = self._notifications.get_by_id(notification_id)
+        if notification is None:
+            raise NotFoundError(f"Notification '{notification_id}' not found.")
+        self._assert_can_read(requesting_user, notification.user_id)
+        return notification

--- a/backend/app/domain/models/notification.py
+++ b/backend/app/domain/models/notification.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class Notification(BaseModel):
+    notification_id: int | None = None
+    user_id: str
+    event_type: str
+    message: str
+    created_at: datetime
+    is_read: bool = False

--- a/backend/app/infrastructure/repositories/notification_repository.py
+++ b/backend/app/infrastructure/repositories/notification_repository.py
@@ -1,21 +1,11 @@
 from datetime import datetime, timezone
-from typing import List, NamedTuple, Optional
+from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
+from backend.app.domain.models.notification import Notification
 from backend.app.infrastructure.orm_models import NotificationORM
 from backend.app.infrastructure.repositories.base_repository import BaseRepository
-
-
-class Notification(NamedTuple):
-
-    notification_id: int
-    user_id: str
-    event_type: str
-    message: str
-    created_at: datetime
-    is_read: bool
-
 
 class NotificationRepository(BaseRepository[Notification, int]):
     def __init__(self, db: Session) -> None:
@@ -36,7 +26,7 @@ class NotificationRepository(BaseRepository[Notification, int]):
             created_at=entity.created_at,
             is_read=entity.is_read,
         )
-        if entity.notification_id:
+        if entity.notification_id is not None:
             orm_obj.notification_id = entity.notification_id
             orm_obj = self._db.merge(orm_obj)
         else:
@@ -112,7 +102,7 @@ class NotificationRepository(BaseRepository[Notification, int]):
             user_id=user_id,
             event_type=event_type,
             message=message,
-            created_at = datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
             is_read=False,
         )
         self._db.add(orm_obj)
@@ -132,4 +122,4 @@ class NotificationRepository(BaseRepository[Notification, int]):
             message=orm_obj.message,
             created_at=created_at,
             is_read=orm_obj.is_read,
-    )
+        )

--- a/backend/app/presentation/routers/notification_router.py
+++ b/backend/app/presentation/routers/notification_router.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from backend.app.application.exceptions import AuthorizationError, NotFoundError
 from backend.app.application.services.notification_service import NotificationService
+from backend.app.domain.models.notification import Notification
 from backend.app.domain.models.user import User
 from backend.app.presentation.dependencies import (
     get_current_user,
@@ -14,7 +15,7 @@ from backend.app.presentation.schemas import NotificationResponse
 router = APIRouter(prefix="/notifications", tags=["Notifications"])
 
 
-def _to_response(notification) -> NotificationResponse:
+def _to_response(notification: Notification) -> NotificationResponse:
     return NotificationResponse(
         notification_id=notification.notification_id,
         user_id=notification.user_id,

--- a/tests/api/test_notification_router.py
+++ b/tests/api/test_notification_router.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 from backend.app.application.exceptions import AuthorizationError, NotFoundError
-from backend.app.infrastructure.repositories.notification_repository import Notification
+from backend.app.domain.models.notification import Notification
 from backend.app.presentation.dependencies import get_notification_service
 
 

--- a/tests/unit/test_notification_repository.py
+++ b/tests/unit/test_notification_repository.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
+from backend.app.domain.models.notification import Notification
 from backend.app.infrastructure.repositories.notification_repository import (
-    Notification,
     NotificationRepository,
 )
 
@@ -12,7 +12,7 @@ def test_save_and_get_by_id(db_session):
 
     saved = repo.save(
         Notification(
-            notification_id=0,
+            notification_id=None,
             user_id="user-1",
             event_type="order_created",
             message="Order created",
@@ -53,10 +53,24 @@ def test_get_by_user_returns_newest_first(db_session):
     newer = datetime.now(timezone.utc)
 
     repo.save(
-        Notification(0, "user-1", "order_created", "Older", older, False)
+        Notification(
+            notification_id=None,
+            user_id="user-1",
+            event_type="order_created",
+            message="Older",
+            created_at=older,
+            is_read=False,
+        )
     )
     repo.save(
-        Notification(0, "user-1", "order_completed", "Newer", newer, False)
+        Notification(
+            notification_id=None,
+            user_id="user-1",
+            event_type="order_completed",
+            message="Newer",
+            created_at=newer,
+            is_read=False,
+        )
     )
     repo.create_notification("user-2", "payment_received", "Other user")
 

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -4,7 +4,7 @@ import pytest
 
 from backend.app.application.exceptions import AuthorizationError, NotFoundError
 from backend.app.application.services.notification_service import NotificationService
-from backend.app.infrastructure.repositories.notification_repository import Notification
+from backend.app.domain.models.notification import Notification
 
 
 def make_service(notification_repo):


### PR DESCRIPTION
 ## Summary
  Refactors the notification flow to improve layering and consistency.

  ## Changes
  - moved `Notification` into the domain layer
  - removed the inline notification model from the repository
  - simplified notification service logic by centralizing notification lookup and access checks
  - updated notification tests to match the refactor

  ## Testing
  - `pytest tests/unit/test_notification_repository.py tests/unit/test_notification_service.py tests/api/test_notification_router.py`