### PR TITLE
Refactor update_restaurant to use single model_copy

### DIFF
--- a/backend/app/application/services/restaurant_service.py
+++ b/backend/app/application/services/restaurant_service.py
@@ -47,12 +47,16 @@ class RestaurantService:
         restaurant = self.get_restaurant(restaurant_id)
         self._check_owner(requesting_user, restaurant)
 
+        changes = {}
         if name is not None:
-            restaurant = restaurant.model_copy(update={"name": name})
+            changes["name"] = name
         if location is not None:
-            restaurant = restaurant.model_copy(update={"location": location})
+            changes["location"] = location
         if description is not None:
-            restaurant = restaurant.model_copy(update={"description": description})
+            changes["description"] = description
+        
+        if changes:
+            restaurant = restaurant.model_copy(update=changes)
         
         return self._restaurants.save(restaurant)
     


### PR DESCRIPTION
Refactored update_restaurant to build a changes dict and do a single model_copy call instead of three separate ones. Avoids creating unnecessary intermediate copies. No behavior changes.

