### PR TITLE
fix _to_domain mapping bug: cuisine_type field doesnt exist

### DIFF
--- a/backend/app/infrastructure/repositories/restaurant_repository.py
+++ b/backend/app/infrastructure/repositories/restaurant_repository.py
@@ -70,7 +70,7 @@ class RestaurantRepository(BaseRepository[Restaurant, str]):
             owner_id=orm_obj.owner_id,
             name=orm_obj.name,
             location=orm_obj.location,
-            cuisine_type=orm_obj.description,
+            description=orm_obj.description,
         )
     
     @staticmethod


### PR DESCRIPTION
Fix bug in restaurant repository _to_domain mapper. The description field was mapped to cuisine_type which doesn't exist on the Restaurant model, causing data loss during conversion. Changed to description=orm_obj.description.