### PR TITLE
replace long parameter list in update_delivery and update test

### DIFF
--- a/backend/app/application/services/delivery_service.py
+++ b/backend/app/application/services/delivery_service.py
@@ -63,48 +63,14 @@ class DeliveryService:
     def list_deliveries(self, offset: int = 0, limit: int = 20) -> List[Delivery]:
         return self._deliveries.get_paginated(offset=offset, limit=limit)
 
-    def update_delivery(
-        self,
-        requesting_user: User,
-        order_id: str,
-        delivery_time_actual: Optional[float] = None,
-        delivery_delay: Optional[float] = None,
-        delivery_method: Optional[DeliveryMethod] = None,
-        route_taken: Optional[str] = None,
-        route_type: Optional[RouteType] = None,
-        route_efficiency: Optional[float] = None,
-        traffic_condition: Optional[str] = None,
-        weather_condition: Optional[str] = None,
-        predicted_delivery_mode: Optional[str] = None,
-        traffic_avoidance: Optional[bool] = None,
-    ) -> Delivery:
+    def update_delivery(self, requesting_user: User, order_id: str, updates: dict) -> Delivery:
         self._check_not_customer(requesting_user)
 
         delivery = self.get_delivery(order_id)
-
-        updates = {}
-        if delivery_time_actual is not None:
-            updates["delivery_time_actual"] = delivery_time_actual
-        if delivery_delay is not None:
-            updates["delivery_delay"] = delivery_delay
-        if delivery_method is not None:
-            updates["delivery_method"] = delivery_method
-        if route_taken is not None:
-            updates["route_taken"] = route_taken
-        if route_type is not None:
-            updates["route_type"] = route_type
-        if route_efficiency is not None:
-            updates["route_efficiency"] = route_efficiency
-        if traffic_condition is not None:
-            updates["traffic_condition"] = traffic_condition
-        if weather_condition is not None:
-            updates["weather_condition"] = weather_condition
-        if predicted_delivery_mode is not None:
-            updates["predicted_delivery_mode"] = predicted_delivery_mode
-        if traffic_avoidance is not None:
-            updates["traffic_avoidance"] = traffic_avoidance
-
-        updated_delivery = delivery.model_copy(update=updates)
+        
+        valid_fields = {k: v for k, v in updates.items() if v is not None}
+        
+        updated_delivery = delivery.model_copy(update=valid_fields)
         return self._deliveries.save(updated_delivery)
     
     def _check_not_customer(self, user: User) -> None:

--- a/backend/app/presentation/routers/delivery_router.py
+++ b/backend/app/presentation/routers/delivery_router.py
@@ -79,15 +79,6 @@ def update_delivery(
     updated = svc.update_delivery(
         requesting_user=current_user,
         order_id=order_id,
-        delivery_time_actual=body.delivery_time_actual,
-        delivery_delay=body.delivery_delay,
-        delivery_method=body.delivery_method,
-        route_taken=body.route_taken,
-        route_type=body.route_type,
-        route_efficiency=body.route_efficiency,
-        traffic_condition=body.traffic_condition,
-        weather_condition=body.weather_condition,
-        predicted_delivery_mode=body.predicted_delivery_mode,
-        traffic_avoidance=body.traffic_avoidance,
+        updates=body.model_dump(exclude_none=True),
     )
     return _to_response(updated)

--- a/tests/unit/test_delivery_service.py
+++ b/tests/unit/test_delivery_service.py
@@ -55,7 +55,7 @@ def test_update_delivery_as_customer_fails(mock_delivery_repo, mock_order_repo, 
     service = DeliveryService(mock_delivery_repo, mock_order_repo)
  
     with pytest.raises(AuthorizationError):
-        service.update_delivery(customer_user, "order-001", traffic_condition="High") 
+         service.update_delivery(customer_user, "order-001", {"traffic_condition": "High"})
  
 def test_negative_delay_threshold(mock_delivery_repo, mock_order_repo):
     service = DeliveryService(mock_delivery_repo, mock_order_repo)


### PR DESCRIPTION
Replaced 10+ parameter list in update_delivery with a single dict parameter. Router now passes body.model_dump(exclude_none=True) instead of listing every field individually. Updated unit test to match new method signature. Follows Introduce Parameter Object refactoring pattern.